### PR TITLE
Add support for auto applies

### DIFF
--- a/app/controllers/api/v2/jobs_controller.rb
+++ b/app/controllers/api/v2/jobs_controller.rb
@@ -22,6 +22,7 @@ module Api
                 .select('DISTINCT ON (workspace_id) *')
                 .where(agent_pool_id: params[:id])
                 .where(locked: false)
+                .where(status: 'pending')
                 .order(workspace_id: :asc, created_at: :desc)
                 .limit(10)
         render json: ::JobSerializer.new(@jobs, {}).serializable_hash

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -18,4 +18,19 @@ class Run < ApplicationRecord
   }
 
   before_create -> { generate_id('run') }
+
+  def has_task_stage(stage)
+    task_stages.find { |task_stage| task_stage.stage == stage }
+  end
+
+  def is_confirmable?
+    return false unless status == 'planned_and_saved'
+
+    if workspace.vcs_connection.present?
+      # This should be updated to support VCS connections
+      return false
+    end
+
+    true
+  end
 end

--- a/app/sidekiq/process_plan_job.rb
+++ b/app/sidekiq/process_plan_job.rb
@@ -62,5 +62,13 @@ class ProcessPlanJob
       has_changes: true,
       status: 'planned_and_saved'
     )
+
+    if @plan.run.is_confirmable? && @plan.run.auto_apply
+      Rails.logger.debug 'auto applying run'
+      @plan.run.update(status: 'confirmed')
+      RunConfirmedJob.perform_async(@plan.run.id)
+    else
+      Rails.logger.debug 'run is not confirmable, or auto apply not set'
+    end
   end
 end

--- a/spec/models/run_spec.rb
+++ b/spec/models/run_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Run do
+  it "is not confirmable when status is not 'planned_and_saved'" do
+    run = described_class.new(status: 'plan_queued')
+    expect(run).not_to be_is_confirmable
+  end
+
+  it "is confirmable when status is 'planned_and_saved'" do
+    run = described_class.new(status: 'planned_and_saved')
+    run.workspace = Workspace.new
+    expect(run).to be_is_confirmable
+  end
+end


### PR DESCRIPTION
Limited support for auto apply. 

This only supports `--auto-approve` flag provided by tofu commands ran manually, not VCS triggered runs